### PR TITLE
feat: Fix Registration Rate Limit (HTTP 429) Error Handling

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      android:usesCleartextTraffic="true">
       <activity
         android:name="com.aossiep2p.MainActivity"
         android:label="@string/app_name"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,8 +18,7 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
-      android:theme="@style/AppTheme"
-      android:usesCleartextTraffic="true">
+      android:theme="@style/AppTheme">
       <activity
         android:name="com.aossiep2p.MainActivity"
         android:label="@string/app_name"

--- a/src/Name.js
+++ b/src/Name.js
@@ -5,7 +5,12 @@ import { generateUId } from "./Utils";
 import { COLORS } from "./assets/Colors";
 import { RSA } from "react-native-rsa-native";
 
-const API_BASE_URL = "http://localhost:3000";
+const getApiBaseUrl = () => {
+  if (__DEV__) {
+    return "http://10.0.2.2:3000";
+  }
+  return "http://YOUR_PRODUCTION_IP:3000";
+};
 
 const Name = ({ navigation }) => {
   const [name, setName] = useState();
@@ -21,11 +26,10 @@ const Name = ({ navigation }) => {
     try {
       const id = generateUId();
       const uid = `${name}@${id}`;
-      await AsyncStorage.setItem("username", name);
-      await AsyncStorage.setItem("uid", uid);
+      const apiBaseUrl = getApiBaseUrl();
 
       try {
-        const response = await fetch(`${API_BASE_URL}/register`, {
+        const response = await fetch(`${apiBaseUrl}/register`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -45,8 +49,17 @@ const Name = ({ navigation }) => {
           Alert.alert("Error", "Registration failed. Please try again.");
           return;
         }
+
+        await AsyncStorage.setItem("username", name);
+        await AsyncStorage.setItem("uid", uid);
       } catch (apiError) {
-        console.log("API not available, proceeding with local registration");
+        console.error("Registration API error:", apiError);
+        Alert.alert(
+          "Offline Mode",
+          "Unable to connect to server. Continuing in offline mode."
+        );
+        await AsyncStorage.setItem("username", name);
+        await AsyncStorage.setItem("uid", uid);
       }
 
       RSA.generateKeys(1024)

--- a/src/Name.js
+++ b/src/Name.js
@@ -1,9 +1,11 @@
 import React, { useState } from "react";
-import { View, Text, StyleSheet, TextInput, Button } from "react-native";
+import { View, Text, StyleSheet, TextInput, Button, Alert } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { generateUId } from "./Utils";
 import { COLORS } from "./assets/Colors";
 import { RSA } from "react-native-rsa-native";
+
+const API_BASE_URL = "http://localhost:3000";
 
 const Name = ({ navigation }) => {
   const [name, setName] = useState();
@@ -22,7 +24,32 @@ const Name = ({ navigation }) => {
       await AsyncStorage.setItem("username", name);
       await AsyncStorage.setItem("uid", uid);
 
-      RSA.generateKeys(1024) // set key size
+      try {
+        const response = await fetch(`${API_BASE_URL}/register`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ username: name, uid: uid }),
+        });
+
+        if (response.status === 429) {
+          Alert.alert(
+            "Rate Limit Reached",
+            "Too many registration attempts. Please wait before trying again."
+          );
+          return;
+        }
+
+        if (!response.ok) {
+          Alert.alert("Error", "Registration failed. Please try again.");
+          return;
+        }
+      } catch (apiError) {
+        console.log("API not available, proceeding with local registration");
+      }
+
+      RSA.generateKeys(1024)
         .then((keys) => {
           keys = JSON.stringify(keys);
           AsyncStorage.setItem(uid, keys)


### PR DESCRIPTION
close #7 

## Summary

This PR improves the registration flow by explicitly handling HTTP 429 (Too Many Requests) responses from the backend.

When the registration rate limit is reached, the app now displays a clear, user-friendly message instead of a generic failure alert.

---

## Changes

Updated `src/Name.js` to:

- Add backend registration API call (`POST /register`)
- Detect and handle HTTP 429 status code explicitly
- Display alert:  
  **"Too many registration attempts. Please wait before trying again."**
- Show generic error message for other registration failures
- Gracefully handle cases where the API is unavailable (offline/local usage)

---

## Testing

- Trigger backend rate limit (3 attempts per hour)
- Verify HTTP 429 displays "Rate Limit Reached" message
- Verify other errors display generic "Registration failed" message
- Confirm app does not crash during error handling

---

This improves onboarding UX and prevents user frustration during registration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registration now includes a server validation step and proceeds only after server confirmation.
* **Bug Fixes**
  * Rate-limit alerts shown when registration is throttled.
  * Improved error messaging for registration failures.
  * Fallback flow allows registration to continue and persist locally when the server is unreachable.
* **Platform**
  * Android: app now permits cleartext network traffic (affects network connections on device).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->